### PR TITLE
add preaggregation pipeline dual shipping support

### DIFF
--- a/comp/forwarder/defaultforwarder/endpoints/endpoints.go
+++ b/comp/forwarder/defaultforwarder/endpoints/endpoints.go
@@ -25,6 +25,8 @@ var (
 
 	// SeriesEndpoint is the v2 endpoint used to send series
 	SeriesEndpoint = transaction.Endpoint{Route: "/api/v2/series", Name: "series_v2"}
+	// PreaggrSeriesEndpoint is the endpoint used for experimental preaggregation
+	PreaggrSeriesEndpoint = transaction.Endpoint{Route: "/api/intake/pipelines/ddseries", Name: "preaggr_series"}
 	// EventsEndpoint is the v2 endpoint used to send events
 	EventsEndpoint = transaction.Endpoint{Route: "/api/v2/events", Name: "events_v2"}
 	// ServiceChecksEndpoint is the v2 endpoint used to send service checks

--- a/comp/forwarder/defaultforwarder/transaction/transaction.go
+++ b/comp/forwarder/defaultforwarder/transaction/transaction.go
@@ -206,6 +206,8 @@ const (
 	SecondaryOnly
 	// LocalOnly indicates the transaction should be sent to the local endpoint (cluster-agent) only
 	LocalOnly
+	// PreaggrOnly indicates the transaction should be sent to the pre-aggregation endpoint only
+	PreaggrOnly
 )
 
 func (d Destination) String() string {
@@ -218,6 +220,8 @@ func (d Destination) String() string {
 		return "SecondaryOnly"
 	case LocalOnly:
 		return "LocalOnly"
+	case PreaggrOnly:
+		return "PreaggrOnly"
 	default:
 		return "Unknown"
 	}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -233,6 +233,7 @@ var serverlessConfigComponents = []func(pkgconfigmodel.Setup){
 	setupAPM,
 	OTLP,
 	setupMultiRegionFailover,
+	setupPreaggregation,
 	telemetry,
 	autoconfig,
 	remoteconfig,

--- a/pkg/config/setup/preaggregation.go
+++ b/pkg/config/setup/preaggregation.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package setup
+
+import (
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+func setupPreaggregation(config pkgconfigmodel.Setup) {
+	config.BindEnvAndSetDefault("enable_preaggr_pipeline", false)
+	config.BindEnvAndSetDefault("preaggr_dd_url", "https://api.datad0g.com")
+	config.BindEnv("preaggr_api_key")
+}

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -106,77 +106,41 @@ func describeItem(serie *metrics.Serie) string {
 	return fmt.Sprintf("name %q, %d points", serie.Name, len(serie.Points))
 }
 
-// MarshalSplitCompress uses the stream compressor to marshal and compress series payloads.
-// If a compressed payload is larger than the max, a new payload will be generated. This method returns a slice of
-// compressed protobuf marshaled MetricPayload objects.
-func (series *IterableSeries) MarshalSplitCompress(bufferContext *marshaler.BufferContext, config config.Component, strategy compression.Component) (transaction.BytesPayloads, error) {
-	pb, err := series.NewPayloadsBuilder(bufferContext, config, strategy)
-	if err != nil {
-		return nil, err
-	}
-
-	err = pb.startPayload()
-	if err != nil {
-		return nil, err
-	}
-
-	// Use series.source.MoveNext() instead of series.MoveNext() because this function supports
-	// the serie.NoIndex field.
-	for series.source.MoveNext() {
-		err = pb.writeSerie(series.source.Current())
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// if the last payload has any data, flush it
-	err = pb.finishPayload()
-	if err != nil {
-		return nil, err
-	}
-
-	return pb.payloads, nil
+type Pipeline struct {
+	FilterFunc  func(s *metrics.Serie) bool
+	Destination transaction.Destination
 }
 
-// MarshalSplitCompressMultiple uses the stream compressor to marshal and compress one series into three sets of payloads.
-// One set of payloads contains all metrics,
-// The seond contains only those that pass the provided MRF filter function.
-// The third contains only those that pass the provided autoscaling local failover filter function.
-// This function exists because we need a way to build both payloads in a single pass over the input data, which cannot be iterated over twice.
-func (series *IterableSeries) MarshalSplitCompressMultiple(config config.Component, strategy compression.Component, filterFuncForMRF func(s *metrics.Serie) bool, filterFuncForAutoscaling func(s *metrics.Serie) bool) (transaction.BytesPayloads, transaction.BytesPayloads, transaction.BytesPayloads, error) {
-	pbs := make([]*PayloadsBuilder, 3) // 0: all, 1: MRF, 2: autoscaling
+// MarshalSplitCompressPipelines uses the stream compressor to marshal and
+// compress series payloads, allowing multiple variants to be generated in a
+// single pass over the input data. If a compressed payload is larger than the
+// max, a new payload will be generated. This method returns a slice of
+// compressed protobuf marshaled MetricPayload objects.
+func (series *IterableSeries) MarshalSplitCompressPipelines(config config.Component, strategy compression.Component, pipelines []Pipeline) (transaction.BytesPayloads, error) {
+	pbs := make([]*PayloadsBuilder, len(pipelines))
 	for i := range pbs {
 		bufferContext := marshaler.NewBufferContext()
 		pb, err := series.NewPayloadsBuilder(bufferContext, config, strategy)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 		pbs[i] = &pb
 
 		err = pbs[i].startPayload()
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 	}
+
 	// Use series.source.MoveNext() instead of series.MoveNext() because this function supports
 	// the serie.NoIndex field.
 	for series.source.MoveNext() {
-		err := pbs[0].writeSerie(series.source.Current())
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		if filterFuncForMRF(series.source.Current()) {
-			err = pbs[1].writeSerie(series.source.Current())
-			if err != nil {
-				return nil, nil, nil, err
-			}
-		}
-
-		if filterFuncForAutoscaling(series.source.Current()) {
-			err = pbs[2].writeSerie(series.source.Current())
-			if err != nil {
-				return nil, nil, nil, err
+		for i, pipeline := range pipelines {
+			if pipeline.FilterFunc(series.source.Current()) {
+				err := pbs[i].writeSerie(series.source.Current())
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -185,11 +149,23 @@ func (series *IterableSeries) MarshalSplitCompressMultiple(config config.Compone
 	for i := range pbs {
 		err := pbs[i].finishPayload()
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 	}
 
-	return pbs[0].payloads, pbs[1].payloads, pbs[2].payloads, nil
+	// assign destinations to payloads per strategy
+	for i, pipeline := range pipelines {
+		for _, payload := range pbs[i].payloads {
+			payload.Destination = pipeline.Destination
+		}
+	}
+
+	payloads := make([]*transaction.BytesPayload, len(pbs))
+	for _, pb := range pbs {
+		payloads = append(payloads, pb.payloads...)
+	}
+
+	return payloads, nil
 }
 
 // NewPayloadsBuilder initializes a new PayloadsBuilder to be used for serializing series into a set of output payloads.

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -8,17 +8,22 @@ package serializer
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"expvar"
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"time"
 
 	forwarder "github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	orchestratorForwarder "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface"
+	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl/hosttags"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -342,54 +347,75 @@ func (s *Serializer) SendIterableSeries(serieSource metrics.SerieSource) error {
 	var extraHeaders http.Header
 	var err error
 
-	if useV1API && s.enableJSONStream {
-		seriesBytesPayloads, extraHeaders, err = s.serializeIterableStreamablePayload(seriesSerializer, stream.DropItemOnErrItemTooBig)
-	} else if useV1API && !s.enableJSONStream {
-		seriesBytesPayloads, extraHeaders, err = s.serializePayloadJSON(seriesSerializer, true)
-	} else {
-		failoverActiveForMRF, allowlistForMRF := s.getFailoverAllowlist()
-		failoverActiveForAutoscaling, allowlistForAutoscaling := s.getAutoscalingFailoverMetrics()
-		failoverActive := (failoverActiveForMRF && len(allowlistForMRF) > 0) || (failoverActiveForAutoscaling && len(allowlistForAutoscaling) > 0)
-		if failoverActive {
-			var filtered transaction.BytesPayloads
-			var localAutoscalingFaioverPayloads transaction.BytesPayloads
-			seriesBytesPayloads, filtered, localAutoscalingFaioverPayloads, err = seriesSerializer.MarshalSplitCompressMultiple(s.config, s.Strategy,
-				func(s *metrics.Serie) bool { // Filter for MRF
-					_, allowed := allowlistForMRF[s.Name]
-					return allowed
-				},
-				func(s *metrics.Serie) bool { // Filter for Autoscaling
-					_, allowed := allowlistForAutoscaling[s.Name]
-					return allowed
-				})
-
-			for _, seriesBytesPayload := range seriesBytesPayloads {
-				seriesBytesPayload.Destination = transaction.PrimaryOnly
-			}
-			for _, seriesBytesPayload := range filtered {
-				seriesBytesPayload.Destination = transaction.SecondaryOnly
-			}
-			for _, seriesBytesPayload := range localAutoscalingFaioverPayloads {
-				seriesBytesPayload.Destination = transaction.LocalOnly
-			}
-			seriesBytesPayloads = append(seriesBytesPayloads, filtered...)
-			seriesBytesPayloads = append(seriesBytesPayloads, localAutoscalingFaioverPayloads...)
+	if useV1API {
+		if s.enableJSONStream {
+			seriesBytesPayloads, extraHeaders, err = s.serializeIterableStreamablePayload(seriesSerializer, stream.DropItemOnErrItemTooBig)
 		} else {
-			seriesBytesPayloads, err = seriesSerializer.MarshalSplitCompress(marshaler.NewBufferContext(), s.config, s.Strategy)
-			for _, seriesBytesPayload := range seriesBytesPayloads {
-				seriesBytesPayload.Destination = transaction.AllRegions
-			}
+			seriesBytesPayloads, extraHeaders, err = s.serializePayloadJSON(seriesSerializer, true)
 		}
-		extraHeaders = s.protobufExtraHeadersWithCompression
+		if err != nil {
+			return fmt.Errorf("dropping series payload: %s", err)
+		}
+		return s.Forwarder.SubmitV1Series(seriesBytesPayloads, extraHeaders)
 	}
+
+	failoverActiveForMRF, allowlistForMRF := s.getFailoverAllowlist()
+	failoverActiveForAutoscaling, allowlistForAutoscaling := s.getAutoscalingFailoverMetrics()
+	failoverActive := (failoverActiveForMRF && len(allowlistForMRF) > 0) || (failoverActiveForAutoscaling && len(allowlistForAutoscaling) > 0)
+	pipelines := make([]metricsserializer.Pipeline, 0, 4)
+	if failoverActive {
+		// Default behavior, primary region only
+		pipelines = append(pipelines, metricsserializer.Pipeline{
+			FilterFunc:  func(series *metrics.Serie) bool { return true },
+			Destination: transaction.PrimaryOnly,
+		})
+
+		// Filter for MRF
+		pipelines = append(pipelines, metricsserializer.Pipeline{
+			FilterFunc: func(s *metrics.Serie) bool {
+				_, allowed := allowlistForMRF[s.Name]
+				return allowed
+			},
+			Destination: transaction.SecondaryOnly,
+		})
+
+		// Filter for Autoscaling
+		pipelines = append(pipelines, metricsserializer.Pipeline{
+			FilterFunc: func(s *metrics.Serie) bool {
+				_, allowed := allowlistForAutoscaling[s.Name]
+				return allowed
+			},
+			Destination: transaction.LocalOnly,
+		})
+	} else {
+		// Default behavior, all regions
+		pipelines = append(pipelines, metricsserializer.Pipeline{
+			FilterFunc:  func(series *metrics.Serie) bool { return true },
+			Destination: transaction.AllRegions,
+		})
+	}
+
+	// We are modifying the series in this filter, so it must always be the last
+	// pipeline in the list to avoid affecting other pipelines.
+	if s.config.GetBool("enable_preaggr_pipeline") {
+		pipelines = append(pipelines, metricsserializer.Pipeline{
+			FilterFunc: func(s *metrics.Serie) bool {
+				// TODO: don't add host tags if they were already added because of `expected_tags_duration` being set
+				hostTags := slices.Clone(hostMetadataUtils.Get(context.TODO(), false, pkgconfigsetup.Datadog()).System)
+				s.Tags = tagset.CombineCompositeTagsAndSlice(s.Tags, hostTags)
+				return true
+			},
+			Destination: transaction.PreaggrOnly,
+		})
+	}
+
+	seriesBytesPayloads, err = seriesSerializer.MarshalSplitCompressPipelines(s.config, s.Strategy, pipelines)
+	extraHeaders = s.protobufExtraHeadersWithCompression
 
 	if err != nil {
 		return fmt.Errorf("dropping series payload: %s", err)
 	}
 
-	if useV1API {
-		return s.Forwarder.SubmitV1Series(seriesBytesPayloads, extraHeaders)
-	}
 	return s.Forwarder.SubmitSeries(seriesBytesPayloads, extraHeaders)
 }
 

--- a/pkg/serializer/series_benchmark_test.go
+++ b/pkg/serializer/series_benchmark_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	metricsserializer "github.com/DataDog/datadog-agent/pkg/serializer/internal/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serializer/internal/stream"
-	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
 
@@ -76,12 +75,16 @@ func BenchmarkSeries(b *testing.B) {
 			b.ReportMetric(float64(payloadCompressedSize)/float64(b.N), "compressed-payload-bytes")
 		}
 	}
-	bufferContext := marshaler.NewBufferContext()
 	mockConfig := mock.New(b)
 	compressor := metricscompression.NewCompressorReq(metricscompression.Requires{Cfg: mockConfig}).Comp
 	pb := func(series metrics.Series) (transaction.BytesPayloads, error) {
 		iterableSeries := metricsserializer.CreateIterableSeries(metricsserializer.CreateSerieSource(series))
-		return iterableSeries.MarshalSplitCompress(bufferContext, mockConfig, compressor)
+		return iterableSeries.MarshalSplitCompressPipelines(mockConfig, compressor, []metricsserializer.Pipeline{{
+			FilterFunc: func(metric *metrics.Serie) bool {
+				return true
+			},
+			Destination: transaction.AllRegions,
+		}})
 	}
 
 	payloadBuilder := stream.NewJSONPayloadBuilder(true, mockConfig, compressor, logmock.New(b))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for a preaggregation pipeline, allowing metrics to be sent to a dedicated preaggregation endpoint with configurable URL and API key.
  - Added configuration options to enable the preaggregation pipeline and specify its endpoint and API key.

- **Refactor**
  - Streamlined the serialization and submission of metrics series using a flexible pipeline abstraction, enabling easier filtering and routing of payloads to various destinations.
  - Replaced hardcoded payload filtering logic with a generalized pipeline approach for improved extensibility and maintainability.

- **Chores**
  - Updated benchmark tests to use the new pipeline-based serialization method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->